### PR TITLE
修改openai的url支持输入版本号，不输入则默认/v1

### DIFF
--- a/Controllers/ArticleSummaryController.php
+++ b/Controllers/ArticleSummaryController.php
@@ -45,7 +45,9 @@ class FreshExtension_ArticleSummary_Controller extends Minz_ActionController
     $successResponse = array(
       'response' => array(
         'data' => array(
-          "oai_url" => rtrim($oai_url, '/') . '/v1/chat/completions',
+          // 判断url是否有版本结尾，如果有版本信息则不添加版本信息，如果没有则默认添加/v1
+          $oai_url = preg_match('/\/v\d+\/?$/', $oai_url) ? rtrim($oai_url, '/') : rtrim($oai_url, '/') . '/v1',
+          "oai_url" => rtrim($oai_url, '/') . '/chat/completions',
           "oai_key" => $oai_key,
           "model" => $oai_model,
           "messages" => [


### PR DESCRIPTION
今天发现智普AI可以使用免费的模型，但它提供的 OpenAI 接口版本是 v4。输入后发现请求失败，查看代码发现默认设置为 v1 版本，打算稍作修改解决问题。
