### PR TITLE
Fix summary button label on article navigation

### DIFF
--- a/extension.php
+++ b/extension.php
@@ -89,7 +89,7 @@ final class ArticleSummaryExtension extends Minz_Extension
       . 'data-loading-text="' . $loadingText . '" '
       . 'data-error-text="' . $errorText . '" '
       . 'data-request-failed-text="' . $requestFailedText . '" '
-      . 'class="oai-summary-btn"></button>'
+      . 'class="oai-summary-btn">' . $summarizeText . '</button>'
       . '<div class="oai-summary-content"></div>'
       . '</div>'
       . $entry->content()

--- a/static/script.js
+++ b/static/script.js
@@ -18,14 +18,6 @@ if (document.readyState && document.readyState !== 'loading') {
 function configureSummarizeButtons() {
   document.getElementById('global').addEventListener('click', function (e) {
     for (var target = e.target; target && target != this; target = target.parentNode) {
-      
-      // Handle article header click to add text to summary button
-      // 处理文章标题点击，为总结按钮添加文本
-      if (target.matches('.flux_header')) {
-        const button = target.nextElementSibling.querySelector('.oai-summary-btn');
-        button.innerHTML = button.dataset.summarizeText;
-      }
-
       // Handle summarize button click
       // 处理总结按钮点击
       if (target.matches('.oai-summary-btn')) {


### PR DESCRIPTION
Fix the issue where the summary button showed only a purple outline without the "Summary" label when navigating between FreshRSS articles with the previous/next controls.

The button text is now rendered server-side instead of being injected only after clicking the article header. This ensures the label is displayed correctly even when opening an article for the first time through navigation.

Close: https://github.com/LiangWei88/xExtension-ArticleSummary/issues/35