### PR TITLE
修复500错误: 为 processNode 方法添加 null 安全检查 || Fix 500 error: add null safety check for processNode method

### DIFF
--- a/Controllers/ArticleSummaryController.php
+++ b/Controllers/ArticleSummaryController.php
@@ -200,7 +200,10 @@ final class FreshExtension_ArticleSummary_Controller extends Minz_ActionControll
    * @param int $indentLevel Indentation level for nested elements
    * @return string Markdown formatted content
    */
-  private function processNode(DOMNode $node, DOMXPath $xpath, int $indentLevel = 0): string {
+  private function processNode(?DOMNode $node, DOMXPath $xpath, int $indentLevel = 0): string {
+    if ($node === null) {
+      return '';
+    }
     $markdown = '';
 
     // Process text nodes


### PR DESCRIPTION
原代码多处直接将 $node->firstChild 传给 processNode()，例如第 256 行（case 'a'）：

case 'a':
  $markdown .= "`";
  $markdown .= $this->processNode($node->firstChild, $xpath);  // firstChild 可能为 null
  $markdown .= "`";
  break;

而 processNode 的参数声明是 DOMNode $node（不可空），PHP 8.x 严格模式下传入 null 会直接抛 TypeError，导致 500。
<!--This is a translation content dividing line, the content below is generated by machine, please do not modify the content below-->
---
The original code directly passes $node->firstChild to processNode() in many places, such as line 256 (case 'a'):

case 'a':
  $markdown .= "`";
  $markdown .= $this->processNode($node->firstChild, $xpath); // firstChild may be null
  $markdown .= "`";
  break;

The parameter declaration of processNode is DOMNode $node (not nullable). In PHP 8.x strict mode, passing in null will directly throw a TypeError, resulting in 500.
